### PR TITLE
[WIP] grenade-project added using haskell.nix

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,25 +1,26 @@
 final: prev: with final; {
 
+  grenade-project = haskell-nix.project {
+    src = ./.;
+    compiler-nix-name = "ghc884";
+    shell.tools = {
+      cabal = "latest";
+      hlint = "latest";
+      haskell-language-server = "latest";
+    };
+    shell.buildInputs = with final; [
 
-  haskellPackages = prev.haskellPackages.override (old: {
-    overrides = lib.composeManyExtensions (with haskell.lib; [
-                  (old.overrides or (_: _: {}))
-                  (self: super: {
-                    colonnade = doJailbreak (markUnbroken super.colonnade);
-                    streaming-utils = doJailbreak (markUnbroken super.streaming-utils);
-                    grenade = haskell-nix.project { src = ./.; };
-                  })
-                  # (packageSourceOverrides { grenade = ./.; })
-                ]);
-  });
+    ];
+  };
 
-  grenade = haskell.lib.justStaticExecutables haskellPackages.grenade;
-
-  # ghcWithgrenade = haskellPackages.ghcWithPackages (p: [ p.grenade ]);
-
-  # ghcWithgrenadeAndPackages = select :
-  #   haskellPackages.ghcWithPackages (p: ([ p.grenade ] ++ select p));
-
+  # haskellPackages = prev.haskellPackages.override (old: {
+  #   overrides = lib.composeManyExtensions (with haskell.lib; [
+  #                 (old.overrides or (_: _: {}))
+  #                 (self: super: {
+  #                   grenade = (grenade-project.flake {}).packages."grenade:lib:grenade";
+  #                 })
+  #               ]);
+  # });
 
   jupyterlab = mkJupyterlab {
     haskellKernelName = "grenade";


### PR DESCRIPTION
Following the `haskell.nix` [scaffolding](https://input-output-hk.github.io/haskell.nix/tutorials/getting-started-flakes.html#scaffolding) I added `grenade-project` to `overlay.nix` and edited `flake.nix` accordingly.
`nix build` seems to work, while `nix develop` does not. Thre are many warning messages.

```sh
grenade on  nixify [✘!?] took 4s
❯ nix build
warning: Git tree '/home/jj/Ocean/haedosa/grenade' is dirty
trace: To make project.stack-nix for haskell-project a fixed-output derivation but not materialized, set `stack-sha256` to the output of the 'calculateMaterializedSha' script in 'passthru'.
trace: To materialize project.stack-nix for haskell-project entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.
trace: WARNING: `cleanSourceWith` called on /nix/store/gj8dq49a1rx6v46pjpz7mlsv4vjmfikx-source without a `name`. Consider adding `name = "gj8dq49a1rx6v46pjpz7mlsv4vjmfikx-source";`
trace: WARNING: 8.8.3 is out of date, consider using 8.8.4.

grenade on  nixify [✘!?] took 4s
❯ nix develop
warning: Git tree '/home/jj/Ocean/haedosa/grenade' is dirty
trace: To make project.stack-nix for haskell-project a fixed-output derivation but not materialized, set `stack-sha256` to the output of the 'calculateMaterializedSha' script in 'passthru'.
trace: To materialize project.stack-nix for haskell-project entirely, pass a writable path as the `materialized` argument and run the 'updateMaterialized' script in 'passthru'.
trace: WARNING: `cleanSourceWith` called on /nix/store/a8b8zncs0bmkmpg2n5ck6k07ksr1ns9k-source without a `name`. Consider adding `name = "a8b8zncs0bmkmpg2n5ck6k07ksr1ns9k-source";`
trace: WARNING: 8.8.3 is out of date, consider using 8.8.4.
error: The Haskell package set does not contain the package: stm (build dependency).
       If you are using Stackage, make sure that you are using a snapshot that contains the package. Otherwise you may need to update the Hackage snapshot you are using, usually by updating haskell.nix.
(use '--show-trace' to show detailed location information)
```